### PR TITLE
Move categories filter from installed to all section

### DIFF
--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -184,7 +184,7 @@ export const Apps = () => {
           ))}
         </div>
 
-        {selectedTab === 'installed' && (
+        {selectedTab === 'all' && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-lg transition-colors">

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -213,11 +213,6 @@ export const Apps = () => {
           <div className="space-y-6">
             {/* Header Section */}
             <div className="text-center py-8">
-              <h2 className="text-2xl font-semibold mb-2">Ghost integrations.</h2>
-              <p className="text-muted-foreground mb-6 max-w-md mx-auto">
-                All your favourite apps, plugins and tools, integrated with Ghost
-              </p>
-              
               {/* Search */}
               <div className="relative max-w-md mx-auto">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -105,7 +105,7 @@ const availableApps: App[] = [
 const categories = ['All Integrations', 'Social', 'Analytics', 'Automation', 'Marketing', 'Development', 'Forms', 'Other'];
 
 export const Apps = () => {
-  const [selectedTab, setSelectedTab] = useState('store');
+  const [selectedTab, setSelectedTab] = useState('all');
   const [showMoreOptions, setShowMoreOptions] = useState<string | null>(null);
   const [installedApps, setInstalledApps] = useState<App[]>([
     {

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -295,7 +295,7 @@ export const Apps = () => {
                   Browse the store to find and install apps that enhance your workflow
                 </p>
                 <Button
-                  onClick={() => setSelectedTab('store')}
+                  onClick={() => setSelectedTab('all')}
                   className="mt-4"
                 >
                   Browse Store

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -160,7 +160,7 @@ export const Apps = () => {
   });
 
   const tabs = [
-    { id: 'store', label: 'Store' },
+    { id: 'all', label: 'All' },
     { id: 'installed', label: 'Installed' }
   ];
 

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -209,7 +209,7 @@ export const Apps = () => {
 
       {/* Tab Content */}
       <div className="space-y-6">
-        {selectedTab === 'store' && (
+        {selectedTab === 'all' && (
           <div className="space-y-6">
             {/* Header Section */}
             <div className="text-center py-8">


### PR DESCRIPTION
## Purpose
Move the categories filter functionality from the 'installed' section to the 'all' section to improve user experience and make filtering available when browsing all apps.

## Code changes
- Changed default selected tab from 'store' to 'all'
- Updated tab label from 'Store' to 'All' 
- Moved categories dropdown filter from `selectedTab === 'installed'` condition to `selectedTab === 'all'` condition
- Updated tab content rendering to use 'all' instead of 'store'
- Removed header text from the all apps section
- Updated button click handler to navigate to 'all' tab instead of 'store'

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/91a6d92c4ccd40daac4e3df8c28f4dcc/neon-verse)

👀 [Preview Link](https://91a6d92c4ccd40daac4e3df8c28f4dcc-neon-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>91a6d92c4ccd40daac4e3df8c28f4dcc</projectId>-->
<!--<branchName>neon-verse</branchName>-->